### PR TITLE
Support default exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,6 +136,9 @@ function beforeParse(e) {
       return substring.replace(importRegex,
         (_substring2, relImportPath, symbolName) => {
         const moduleId = getModuleId(e.filename, relImportPath);
+        if (symbolName === 'default') {
+          return path.basename(relImportPath, path.extname(relImportPath));
+        }
         return (moduleId) ? `module:${moduleId}${symbolName?"~"+symbolName:""}` : symbolName;
       });
     });

--- a/index.js
+++ b/index.js
@@ -137,7 +137,9 @@ function beforeParse(e) {
         (_substring2, relImportPath, symbolName) => {
         const moduleId = getModuleId(e.filename, relImportPath);
         if (symbolName === 'default') {
-          return path.basename(relImportPath, path.extname(relImportPath));
+          return (moduleId) ?
+            `module:${moduleId}` :
+            path.basename(relImportPath, path.extname(relImportPath));
         }
         return (moduleId) ? `module:${moduleId}${symbolName?"~"+symbolName:""}` : symbolName;
       });


### PR DESCRIPTION
Currently the plugin doesn't handle `{import('./module').default}` syntax correctly if it's specified as type, despite that VS Code handles it well. With the change, the name of the module file will be used as the name of the type in JSDoc (a typical use case when classes are exported). The change is not expected to be breaking: `default` is a reserved word, and exports can't be named like that.