### PR TITLE
Regex replace paren notation with dot notation for properties on types #14

### DIFF
--- a/index.js
+++ b/index.js
@@ -224,6 +224,7 @@ function jsdocCommentFound(e) {
   if (!typeDefsSet) return;
 
   e.comment = e.comment.replace(typeRegex, (typeExpr) => {
+    typeExpr = typeExpr.replace(/\[["'](.*)['"]\]/g, ".$1"); 
     return typeExpr.replace(identifiers, (identifier) => {
       return (fileInfo.moduleId && typeDefsSet.has(identifier)) ?
         `module:${fileInfo.moduleId}~${identifier}` :


### PR DESCRIPTION
this change will allow JSDoc to parse any docstrings using the syntax in #14 which is used by VSCode / intellisense. Currently, JSDoc throws if it encounters these, when this plugin successfully imports them from another file.

The output is the same as if dot notation was used to reference a type's property (JSDoc compatible).

### index.js:226
```javascript
  e.comment = e.comment.replace(typeRegex, (typeExpr) => {
    typeExpr = typeExpr.replace(/\[["'](.*)['"]\]/g, ".$1"); 
    return typeExpr.replace(identifiers, (identifier) => {
      return (fileInfo.moduleId && typeDefsSet.has(identifier)) ?
        `module:${fileInfo.moduleId}~${identifier}` : identifier
```

There is a separate issue where dot notation used on a type to reference a property is not correctly assigned to the module - which this PR doesn't fix, but it does fix the issue above and allow docs to be built.

